### PR TITLE
build i686 cfg arch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,15 +31,6 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -95,6 +86,26 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "blas"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280f3f48ac4edf086d59c7aa71fb28b78df2b14db8f591fb4eb29b88b77ac6ad"
+dependencies = [
+ "blas-sys",
+ "libc",
+ "num-complex",
+]
+
+[[package]]
+name = "blas-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49cc48acc7ead5c33d2e3cac9c47e55bfd04c929abd1456459084a8c8cdf2cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "bumpalo"
@@ -559,20 +570,6 @@ dependencies = [
 
 [[package]]
 name = "lax"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f96a229d9557112e574164f8024ce703625ad9f88a90964c1780809358e53da"
-dependencies = [
- "cauchy",
- "katexit",
- "lapack-sys",
- "num-traits",
- "openblas-src",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "lax"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1048f58cdc36e726e1c5ef81ec7ac9b1be2fce6b705786514b5a4f8c63487867"
@@ -666,7 +663,7 @@ version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -706,27 +703,11 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "approx 0.4.0",
- "cblas-sys",
- "libc",
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "cblas-sys",
  "libc",
  "matrixmultiply",
@@ -742,30 +723,14 @@ dependencies = [
 
 [[package]]
 name = "ndarray-linalg"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e8dda0c941b64a85c5deb2b3e0144aca87aced64678adfc23eacea6d2cc42"
-dependencies = [
- "cauchy",
- "katexit",
- "lax 0.16.0",
- "ndarray 0.15.6",
- "num-complex",
- "num-traits",
- "rand 0.8.5",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndarray-linalg"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "820b7fdcc3f1fd48c31f4c85bdefe93ef2d0e8b69ff955c4d499ea6db2f19d44"
 dependencies = [
  "cauchy",
  "katexit",
- "lax 0.17.0",
- "ndarray 0.16.1",
+ "lax",
+ "ndarray",
  "num-complex",
  "num-traits",
  "rand 0.8.5",
@@ -774,11 +739,11 @@ dependencies = [
 
 [[package]]
 name = "ndarray-rand"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65608f937acc725f5b164dcf40f4f0bc5d67dc268ab8a649d3002606718c4588"
+checksum = "f093b3db6fd194718dcdeea6bd8c829417deae904e3fcc7732dabcd4416d25d8"
 dependencies = [
- "ndarray 0.15.6",
+ "ndarray",
  "rand 0.8.5",
  "rand_distr 0.4.3",
 ]
@@ -964,10 +929,10 @@ dependencies = [
 name = "powell-opt"
 version = "0.1.0"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "cargo-husky",
- "ndarray 0.16.1",
- "ndarray-linalg 0.17.0",
+ "ndarray",
+ "ndarray-linalg",
  "openssl",
  "openssl-probe",
  "pyo3",
@@ -1277,12 +1242,12 @@ dependencies = [
 
 [[package]]
 name = "scirs2-core"
-version = "0.1.0-alpha.1"
-source = "git+https://github.com/lmmx/scirs?branch=test-powell-quadratic#42e7d6879e585cad387f915b2c2f7d1c8de51bc7"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/lmmx/scirs?branch=patch-1#e8254d0423ac0533a14cfd7647321d374599e632"
 dependencies = [
  "chrono",
- "ndarray 0.16.1",
- "ndarray-linalg 0.16.0",
+ "ndarray",
+ "ndarray-linalg",
  "num-complex",
  "num-traits",
  "once_cell",
@@ -1297,15 +1262,17 @@ dependencies = [
 
 [[package]]
 name = "scirs2-linalg"
-version = "0.1.0-alpha.1"
-source = "git+https://github.com/lmmx/scirs?branch=test-powell-quadratic#42e7d6879e585cad387f915b2c2f7d1c8de51bc7"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/lmmx/scirs?branch=patch-1#e8254d0423ac0533a14cfd7647321d374599e632"
 dependencies = [
- "approx 0.5.1",
+ "approx",
+ "blas",
  "nalgebra",
- "ndarray 0.16.1",
+ "ndarray",
  "ndarray-rand",
  "num-complex",
  "num-traits",
+ "openblas-src",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "rand_distr 0.5.1",
@@ -1317,13 +1284,14 @@ dependencies = [
 
 [[package]]
 name = "scirs2-optimize"
-version = "0.1.0-alpha.1"
-source = "git+https://github.com/lmmx/scirs?branch=test-powell-quadratic#42e7d6879e585cad387f915b2c2f7d1c8de51bc7"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/lmmx/scirs?branch=patch-1#e8254d0423ac0533a14cfd7647321d374599e632"
 dependencies = [
  "argmin",
- "ndarray 0.16.1",
+ "ndarray",
  "num-complex",
  "num-traits",
+ "openblas-src",
  "scirs2-core",
  "scirs2-linalg",
  "thiserror 2.0.12",
@@ -1396,7 +1364,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-complex",
  "num-traits",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,15 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -570,6 +579,20 @@ dependencies = [
 
 [[package]]
 name = "lax"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f96a229d9557112e574164f8024ce703625ad9f88a90964c1780809358e53da"
+dependencies = [
+ "cauchy",
+ "katexit",
+ "lapack-sys",
+ "num-traits",
+ "openblas-src",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "lax"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1048f58cdc36e726e1c5ef81ec7ac9b1be2fce6b705786514b5a4f8c63487867"
@@ -663,7 +686,7 @@ version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -703,11 +726,27 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "approx 0.4.0",
+ "cblas-sys",
+ "libc",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "cblas-sys",
  "libc",
  "matrixmultiply",
@@ -723,14 +762,30 @@ dependencies = [
 
 [[package]]
 name = "ndarray-linalg"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e8dda0c941b64a85c5deb2b3e0144aca87aced64678adfc23eacea6d2cc42"
+dependencies = [
+ "cauchy",
+ "katexit",
+ "lax 0.16.0",
+ "ndarray 0.15.6",
+ "num-complex",
+ "num-traits",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndarray-linalg"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "820b7fdcc3f1fd48c31f4c85bdefe93ef2d0e8b69ff955c4d499ea6db2f19d44"
 dependencies = [
  "cauchy",
  "katexit",
- "lax",
- "ndarray",
+ "lax 0.17.0",
+ "ndarray 0.16.1",
  "num-complex",
  "num-traits",
  "rand 0.8.5",
@@ -739,11 +794,22 @@ dependencies = [
 
 [[package]]
 name = "ndarray-rand"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65608f937acc725f5b164dcf40f4f0bc5d67dc268ab8a649d3002606718c4588"
+dependencies = [
+ "ndarray 0.15.6",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+]
+
+[[package]]
+name = "ndarray-rand"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f093b3db6fd194718dcdeea6bd8c829417deae904e3fcc7732dabcd4416d25d8"
 dependencies = [
- "ndarray",
+ "ndarray 0.16.1",
  "rand 0.8.5",
  "rand_distr 0.4.3",
 ]
@@ -929,14 +995,15 @@ dependencies = [
 name = "powell-opt"
 version = "0.1.0"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "cargo-husky",
- "ndarray",
- "ndarray-linalg",
+ "ndarray 0.16.1",
+ "ndarray-linalg 0.17.0",
  "openssl",
  "openssl-probe",
  "pyo3",
- "scirs2-optimize",
+ "scirs2-optimize 0.1.0-alpha.1",
+ "scirs2-optimize 0.1.0-alpha.2",
 ]
 
 [[package]]
@@ -1242,12 +1309,32 @@ dependencies = [
 
 [[package]]
 name = "scirs2-core"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/lmmx/scirs?branch=test-powell-quadratic#42e7d6879e585cad387f915b2c2f7d1c8de51bc7"
+dependencies = [
+ "chrono",
+ "ndarray 0.16.1",
+ "ndarray-linalg 0.16.0",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "rand 0.9.1",
+ "rand_distr 0.5.1",
+ "rayon",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "wide",
+]
+
+[[package]]
+name = "scirs2-core"
 version = "0.1.0-alpha.2"
 source = "git+https://github.com/lmmx/scirs?branch=patch-1#e8254d0423ac0533a14cfd7647321d374599e632"
 dependencies = [
  "chrono",
- "ndarray",
- "ndarray-linalg",
+ "ndarray 0.16.1",
+ "ndarray-linalg 0.17.0",
  "num-complex",
  "num-traits",
  "once_cell",
@@ -1262,14 +1349,34 @@ dependencies = [
 
 [[package]]
 name = "scirs2-linalg"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/lmmx/scirs?branch=test-powell-quadratic#42e7d6879e585cad387f915b2c2f7d1c8de51bc7"
+dependencies = [
+ "approx 0.5.1",
+ "nalgebra",
+ "ndarray 0.16.1",
+ "ndarray-rand 0.14.0",
+ "num-complex",
+ "num-traits",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_distr 0.5.1",
+ "rayon",
+ "scirs2-core 0.1.0-alpha.1",
+ "thiserror 2.0.12",
+ "wide",
+]
+
+[[package]]
+name = "scirs2-linalg"
 version = "0.1.0-alpha.2"
 source = "git+https://github.com/lmmx/scirs?branch=patch-1#e8254d0423ac0533a14cfd7647321d374599e632"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "blas",
  "nalgebra",
- "ndarray",
- "ndarray-rand",
+ "ndarray 0.16.1",
+ "ndarray-rand 0.15.0",
  "num-complex",
  "num-traits",
  "openblas-src",
@@ -1277,9 +1384,23 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_distr 0.5.1",
  "rayon",
- "scirs2-core",
+ "scirs2-core 0.1.0-alpha.2",
  "thiserror 2.0.12",
  "wide",
+]
+
+[[package]]
+name = "scirs2-optimize"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/lmmx/scirs?branch=test-powell-quadratic#42e7d6879e585cad387f915b2c2f7d1c8de51bc7"
+dependencies = [
+ "argmin",
+ "ndarray 0.16.1",
+ "num-complex",
+ "num-traits",
+ "scirs2-core 0.1.0-alpha.1",
+ "scirs2-linalg 0.1.0-alpha.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1288,12 +1409,12 @@ version = "0.1.0-alpha.2"
 source = "git+https://github.com/lmmx/scirs?branch=patch-1#e8254d0423ac0533a14cfd7647321d374599e632"
 dependencies = [
  "argmin",
- "ndarray",
+ "ndarray 0.16.1",
  "num-complex",
  "num-traits",
  "openblas-src",
- "scirs2-core",
- "scirs2-linalg",
+ "scirs2-core 0.1.0-alpha.2",
+ "scirs2-linalg 0.1.0-alpha.2",
  "thiserror 2.0.12",
 ]
 
@@ -1364,7 +1485,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "num-complex",
  "num-traits",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,23 @@
 [dependencies]
 pyo3 = "0.24.2"
-#scirs2-optimize = { version = "0.1.0-alpha.1", git = "https://github.com/lmmx/scirs", branch = "test-powell-quadratic" }
-scirs2-optimize = { version = "0.1.0-alpha.2", git = "https://github.com/lmmx/scirs", branch = "patch-1" }
 ndarray = "0.16.1"
 # For CI wheel building:
 # https://github.com/PyO3/maturin-action/discussions/162#discussioncomment-7978369
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 ndarray-linalg = { version = "0.17" }
 openssl-probe = { version = "0.1", optional = true }
+
+#scirs2-optimize = { version = "0.1.0-alpha.1", git = "https://github.com/lmmx/scirs", branch = "test-powell-quadratic" }
+#scirs2-optimize = { version = "0.1.0-alpha.2", git = "https://github.com/lmmx/scirs", branch = "patch-1" }
+
+# This branch won't work with aarch64 cross-compilation (lax v0.17.0 shipped a fix)
+# https://github.com/rust-ndarray/ndarray-linalg/pull/354
+[target.'cfg(not(target_arch = "aarch64"))'.dependencies]
+scirs2_optimize = { package = "scirs2-optimize", version = "0.1.0-alpha.1", git = "https://github.com/lmmx/scirs", branch = "test-powell-quadratic" }
+
+# This branch makes i686 behave oddly, gate it to just use on aarch64
+[target.aarch64-unknown-linux-gnu.dependencies]
+scirs2_optimize_aarch64 = { package = "scirs2-optimize", version = "0.1.0-alpha.2", git = "https://github.com/lmmx/scirs", branch = "patch-1" }
 
 [features]
 openblas-system = ["ndarray-linalg/openblas-system"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [dependencies]
 pyo3 = "0.24.2"
-scirs2-optimize = { version = "0.1.0-alpha.1", git = "https://github.com/lmmx/scirs", branch = "test-powell-quadratic" }
+#scirs2-optimize = { version = "0.1.0-alpha.1", git = "https://github.com/lmmx/scirs", branch = "test-powell-quadratic" }
+scirs2-optimize = { version = "0.1.0-alpha.2", git = "https://github.com/lmmx/scirs", branch = "patch-1" }
 ndarray = "0.16.1"
 # For CI wheel building:
 # https://github.com/PyO3/maturin-action/discussions/162#discussioncomment-7978369

--- a/src/options.rs
+++ b/src/options.rs
@@ -63,6 +63,7 @@ impl From<PyOptions> for Options {
             finite_diff_rel_step: options.finite_diff_rel_step,
             disp: options.disp,
             return_all: options.return_all,
+            ..Options::default()
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -54,6 +54,19 @@ impl PyOptions {
 }
 
 impl From<PyOptions> for Options {
+    #[cfg(not(target_arch = "aarch64"))]
+    fn from(options: PyOptions) -> Self {
+        Options {
+            maxiter: options.maxiter,
+            ftol: options.ftol,
+            gtol: options.gtol,
+            eps: options.eps,
+            finite_diff_rel_step: options.finite_diff_rel_step,
+            disp: options.disp,
+            return_all: options.return_all,
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
     fn from(options: PyOptions) -> Self {
         Options {
             maxiter: options.maxiter,


### PR DESCRIPTION
- **build: try with patched scirs**
  - rewound #6 to a1903aa
- **build: feature-conditional compilation (should still work on x86_64 and i686 but fail on aarch)**
  - 2nd attempt to do this after getting known good state merged in #5 

This doesn't build locally but I expect it **will** still build on CI. I expect:
- x86_64 will finish first (it will use the scirs2-optimize alpha-2 version from my patch-1 branch)
- i686 will finish in 6 mins (not taking 2 hours because we are using conditional cargo dependencies to keep it on the scirs2-optimize alpha-1 version from my original [merged/contributed] test-powell-quadratic branch)
- aarch64 will (once its config is put in properly) finish fine