### PR TITLE
(DRAFTING) build aarch v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Confirm commit message matched
         run: |
           echo "Commit message matched the condition."
-          rm build.rs || exit 1
   #   # This job only runs if the commit message meets the condition
   #   if: >
   #     (

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Confirm commit message matched
-        run: echo "Commit message matched the condition."
+        run: |
+          echo "Commit message matched the condition."
+          rm build.rs || exit 1
   #   # This job only runs if the commit message meets the condition
   #   if: >
   #     (

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -180,7 +180,7 @@ jobs:
         uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter ${{ matrix.platform.features }}
+          args: --release --out dist --find-interpreter ${{ matrix.platform.features }} --no-default-features
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: ${{ matrix.platform.manylinux }}
           before-script-linux: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,11 +105,44 @@ jobs:
           - runner: ubuntu-22.04
             target: aarch64
             before: |
-              set -e
-              sudo apt-get update -y && sudo apt-get install pkg-config -y
-            dockeropts: --env OPENSSL_DIR=/usr
-            features: "--features openssl-vendored"
-            manylinux: 2_28
+              sudo apt-get update -y && sudo apt-get install -y \
+                libssl-dev \
+                libopenblas-dev \
+                liblapack-dev \
+                crossbuild-essential-arm64 \
+                gcc-aarch64-linux-gnu \
+                g++-aarch64-linux-gnu \
+                binutils-aarch64-linux-gnu \
+                pkg-config || exit 1
+
+              which gcc && \
+              ls -l /usr/bin/aarch64-linux-gnu-gcc && \
+              /usr/bin/aarch64-linux-gnu-gcc --version && \
+              aarch64-linux-gnu-gcc --version && \
+              mkdir -p .cargo || exit 1
+
+              rustup target add aarch64-unknown-linux-gnu
+
+              cat > .cargo/config.toml << EOF
+              [build]
+              target = "aarch64-unknown-linux-gnu"
+
+              [target.aarch64-unknown-linux-gnu]
+              # no extra rustflags
+              EOF
+            dockeropts: >
+              --env CC_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-gcc
+              --env LIBRARY_PATH=/usr/lib:/usr/lib/aarch64-linux-gnu:$LIBRARY_PATH
+              --env LD_LIBRARY_PATH=/usr/lib:/usr/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
+              --env PKG_CONFIG_ALLOW_CROSS=1
+              --env PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/lib64/pkgconfig
+              --env OPENSSL_DIR=/usr
+              --env OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+              --env OPENBLAS_TARGET=ARMV8
+              --env OPENBLAS_CC=/usr/bin/aarch64-linux-gnu-gcc
+              --env OPENBLAS_HOSTCC=/usr/bin/gcc
+            features: "--features openssl-vendored,openblas-system"
+            manylinux: auto
 
           - runner: ubuntu-22.04
             target: armv7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -181,7 +181,7 @@ jobs:
         uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --find-interpreter ${{ matrix.platform.features }}
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: ${{ matrix.platform.manylinux }}
           before-script-linux: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
               set -e
               yum install -y openssl-devel || exit 1
             dockeropts: ""
-            features: ""
+            features: "--features ci-build"
             manylinux: auto
 
           - runner: ubuntu-22.04
@@ -100,7 +100,7 @@ jobs:
               --env OPENBLAS_TARGET=CORE2
               --env OPENBLAS_CC=/usr/bin/i686-linux-gnu-gcc
               --env OPENBLAS_HOSTCC=/usr/bin/gcc
-            features: "--features openblas-system"
+            features: "--features ci-build,openblas-system"
             manylinux: 2_28
 
           - runner: ubuntu-22.04
@@ -142,7 +142,7 @@ jobs:
               --env OPENBLAS_TARGET=ARMV8
               --env OPENBLAS_CC=/usr/bin/aarch64-linux-gnu-gcc
               --env OPENBLAS_HOSTCC=/usr/bin/gcc
-            features: "--features openssl-vendored,openblas-system"
+            features: "--features openssl-vendored,openblas-system,ci-build"
             manylinux: auto
 
           - runner: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
  "cargo-husky",
  "ndarray 0.16.1",
  "ndarray-linalg 0.17.0",
+ "openblas-src",
  "openssl",
  "openssl-probe",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ openssl-probe = { version = "0.1", optional = true }
 
 # This branch won't work with aarch64 cross-compilation (lax v0.17.0 shipped a fix)
 # https://github.com/rust-ndarray/ndarray-linalg/pull/354
-[target.'cfg(not(target_arch = "aarch64"))'.dependencies]
+[target.'cfg(not(all(target_arch = "aarch64", target_os = "linux")))'.dependencies]
 scirs2_optimize = { package = "scirs2-optimize", version = "0.1.0-alpha.1", git = "https://github.com/lmmx/scirs", branch = "test-powell-quadratic" }
 
 # This branch makes i686 behave oddly, gate it to just use on aarch64
-[target.aarch64-unknown-linux-gnu.dependencies]
+[target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
 scirs2_optimize_aarch64 = { package = "scirs2-optimize", version = "0.1.0-alpha.2", git = "https://github.com/lmmx/scirs", branch = "patch-1" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,8 @@ approx = "0.5.1"
 cargo-husky = { version = "1.5.0", default-features = false, features = [
   "user-hooks",
 ] }
+
+[build-dependencies]
+openblas-src = { version = "0.10", default-features = false, features = [
+  "system",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ openssl = { version = "0.10", features = ["vendored"], optional = true }
 ndarray-linalg = { version = "0.17" }
 openssl-probe = { version = "0.1", optional = true }
 
+openblas-src = { version = "0.10", default-features = false, features = [
+  "system",
+], optional = true }
+
 #scirs2-optimize = { version = "0.1.0-alpha.1", git = "https://github.com/lmmx/scirs", branch = "test-powell-quadratic" }
 #scirs2-optimize = { version = "0.1.0-alpha.2", git = "https://github.com/lmmx/scirs", branch = "patch-1" }
 
@@ -20,6 +24,9 @@ scirs2_optimize = { package = "scirs2-optimize", version = "0.1.0-alpha.1", git 
 scirs2_optimize_aarch64 = { package = "scirs2-optimize", version = "0.1.0-alpha.2", git = "https://github.com/lmmx/scirs", branch = "patch-1" }
 
 [features]
+default = ["local-build"]
+local-build = ["dep:openblas-src"]
+ci-build = []
 openblas-system = ["ndarray-linalg/openblas-system"]
 openssl-vendored = ["dep:openssl", "dep:openssl-probe"]
 
@@ -51,9 +58,4 @@ strip = "symbols"
 approx = "0.5.1"
 cargo-husky = { version = "1.5.0", default-features = false, features = [
   "user-hooks",
-] }
-
-[build-dependencies]
-openblas-src = { version = "0.10", default-features = false, features = [
-  "system",
 ] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+extern crate openblas_src;
+
+fn main() {}

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,0 @@
-extern crate openblas_src;
-
-fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,13 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
-use scirs2_optimize::OptimizeError;
-use scirs2_optimize::unconstrained::{Method, minimize};
+// For Linux aarch64
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+use scirs2_optimize_aarch64::{OptimizeError, unconstrained::{Method, minimize}};
+
+// For everything else (non-aarch64 or non-Linux)
+#[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
+use scirs2_optimize::{OptimizeError, unconstrained::{Method, minimize}};
 
 mod options;
 mod result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 // lib.rs
+#[cfg(feature = "local-build")]
+extern crate openblas_src;
+
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,17 @@ use pyo3::types::PyList;
 
 // For Linux aarch64
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-use scirs2_optimize_aarch64::{OptimizeError, unconstrained::{Method, minimize}};
+use scirs2_optimize_aarch64::{
+    OptimizeError,
+    unconstrained::{Method, minimize},
+};
 
 // For everything else (non-aarch64 or non-Linux)
 #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
-use scirs2_optimize::{OptimizeError, unconstrained::{Method, minimize}};
+use scirs2_optimize::{
+    OptimizeError,
+    unconstrained::{Method, minimize},
+};
 
 mod options;
 mod result;

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,5 +1,12 @@
 // options.rs
 use pyo3::prelude::*;
+
+// For Linux aarch64
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+use scirs2_optimize_aarch64::unconstrained::Options;
+
+// For everything else (non-aarch64 or non-Linux)
+#[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
 use scirs2_optimize::unconstrained::Options;
 
 /// Options for the Powell optimizer

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,13 @@
 use super::*;
 use approx::assert_relative_eq;
 use ndarray::Array1;
+
+// For Linux aarch64
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+use scirs2_optimize_aarch64::unconstrained::Options;
+
+// For everything else (non-aarch64 or non-Linux)
+#[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
 use scirs2_optimize::unconstrained::Options;
 
 fn quadratic(x: &[f64]) -> f64 {


### PR DESCRIPTION
Branched off #8 at 1766ee4

- **build: aarch64 wheel**
- **fix: incorrect inverted arch cfg**
- **build: arch-conditional compilation**
- **build: build script trick to make local compilation work**
- **fix: NO FEATURES WERE BEING PASSED!**
- **build: (push local changed, unsure what effect)**

The last of those commits was essential to making it build locally (thus passing prepush checks), prior to that I'd tried to supply openblas-src with build-deps, it must be a real dep but activated by cfg (I used build.rs to supply the openblas_src previously)

Here I make the openblas-src dep optional and use a default feature to activate it.

What happens now is I've told it to use openblas-src, ...and I expected it to pass the features but it doesn't. Maybe I still need to un-gate that local-build feature too